### PR TITLE
Refactor the fields keyword to 'record' for proper validation.

### DIFF
--- a/src/main/riddl/AllIdsProjections/allIdsProjections.riddl
+++ b/src/main/riddl/AllIdsProjections/allIdsProjections.riddl
@@ -20,7 +20,7 @@ result AllSkus is {skus: SKU*}
 
 context AllIdsProjections is  {
   projection AllTenantIdsView is {
-     record fields {
+     record AllTenantIdsFields {
         tenant: TenantId
         //tenantStatus: TenantContext.Status
     }
@@ -38,7 +38,7 @@ context AllIdsProjections is  {
   }
 
   projection AllOrgIdsView is {
-     record fields {
+     record AllOrgIdsFields {
         org: OrganizationId
         //orgStatus: OrganizationContext.Status
     }
@@ -56,7 +56,7 @@ context AllIdsProjections is  {
   }
 
   projection AllEventIdsView is {
-     record fields {
+     record AllEventIdsFields{
         event: EventId
         //eventStatus: EventContext.Status
     }
@@ -86,7 +86,7 @@ context AllIdsProjections is  {
   }
 
   projection AllMemberIdsView is {
-     record fields {
+     record AllMemberIdsFields {
         member: MemberId,
         memberStatus: MembersContext.Status
     }
@@ -104,7 +104,7 @@ context AllIdsProjections is  {
   }
 
   projection AllStoreIdsView is {
-     record fields {
+     record AllStoreIdsFields {
         store: StoreId
     }
     handler AllStoreIdsViewHandler is {
@@ -118,7 +118,7 @@ context AllIdsProjections is  {
   }
 
   projection AllSkusView is {
-     record fields {
+     record AllSkusFields {
         sku: SKU
     }
     handler AllSkusViewHandler is {

--- a/src/main/riddl/AllIdsProjections/allIdsProjections.riddl
+++ b/src/main/riddl/AllIdsProjections/allIdsProjections.riddl
@@ -20,7 +20,7 @@ result AllSkus is {skus: SKU*}
 
 context AllIdsProjections is  {
   projection AllTenantIdsView is {
-     fields {
+     record fields {
         tenant: TenantId
         //tenantStatus: TenantContext.Status
     }
@@ -38,7 +38,7 @@ context AllIdsProjections is  {
   }
 
   projection AllOrgIdsView is {
-     fields {
+     record fields {
         org: OrganizationId
         //orgStatus: OrganizationContext.Status
     }
@@ -56,7 +56,7 @@ context AllIdsProjections is  {
   }
 
   projection AllEventIdsView is {
-     fields {
+     record fields {
         event: EventId
         //eventStatus: EventContext.Status
     }
@@ -86,7 +86,7 @@ context AllIdsProjections is  {
   }
 
   projection AllMemberIdsView is {
-     fields {
+     record fields {
         member: MemberId,
         memberStatus: MembersContext.Status
     }
@@ -104,7 +104,7 @@ context AllIdsProjections is  {
   }
 
   projection AllStoreIdsView is {
-     fields {
+     record fields {
         store: StoreId
     }
     handler AllStoreIdsViewHandler is {
@@ -118,7 +118,7 @@ context AllIdsProjections is  {
   }
 
   projection AllSkusView is {
-     fields {
+     record fields {
         sku: SKU
     }
     handler AllSkusViewHandler is {

--- a/src/main/riddl/Events/eventReservationProjections.riddl
+++ b/src/main/riddl/Events/eventReservationProjections.riddl
@@ -6,7 +6,7 @@ result NoLocationForEventReservation is {}
 
 context EventReservationProjections is  {
   projection EventReservationView is {
-     fields {
+     record fields {
         event: EventId,
         location: LocationId,
         reservation: ReservationId

--- a/src/main/riddl/Events/eventReservationProjections.riddl
+++ b/src/main/riddl/Events/eventReservationProjections.riddl
@@ -6,7 +6,7 @@ result NoLocationForEventReservation is {}
 
 context EventReservationProjections is  {
   projection EventReservationView is {
-     record fields {
+     record EventReservationFields {
         event: EventId,
         location: LocationId,
         reservation: ReservationId

--- a/src/main/riddl/LocationsReservationsProjections/locationsReservationsProjections.riddl
+++ b/src/main/riddl/LocationsReservationsProjections/locationsReservationsProjections.riddl
@@ -10,7 +10,7 @@ result EasyScheduledEvent is {locations: LocationId+}
 
 context LocationsReservationsProjections is  {
   projection LocationsReservationsView is {
-     record fields {
+     record LocationsReservationsFields {
         venueId: VenueId,
         orgId: OrganizationId,
         locationId: LocationId,

--- a/src/main/riddl/LocationsReservationsProjections/locationsReservationsProjections.riddl
+++ b/src/main/riddl/LocationsReservationsProjections/locationsReservationsProjections.riddl
@@ -10,7 +10,7 @@ result EasyScheduledEvent is {locations: LocationId+}
 
 context LocationsReservationsProjections is  {
   projection LocationsReservationsView is {
-     fields {
+     record fields {
         venueId: VenueId,
         orgId: OrganizationId,
         locationId: LocationId,

--- a/src/main/riddl/MembersAttendingEventsForAnOrganizationProjection/membersAttendingEventsForAnOrganizationProjection.riddl
+++ b/src/main/riddl/MembersAttendingEventsForAnOrganizationProjection/membersAttendingEventsForAnOrganizationProjection.riddl
@@ -4,7 +4,7 @@ result MembersAtEventsOnDay is {memberEvents: MemberEvents+}
 
 context MembersAttendingEventsForAnOrganizationProjection is  {
   projection MembersAttendingEventsForAnOrganizationView is {
-    record fields {
+    record MembersAttendingEventsForAnOrganizationFields {
         event: EventId,     //ticket-event & org-event correlation tables, event table
         eventName: String,  //event table
         eventDate: Date,     //event table

--- a/src/main/riddl/MembersAttendingEventsForAnOrganizationProjection/membersAttendingEventsForAnOrganizationProjection.riddl
+++ b/src/main/riddl/MembersAttendingEventsForAnOrganizationProjection/membersAttendingEventsForAnOrganizationProjection.riddl
@@ -4,7 +4,7 @@ result MembersAtEventsOnDay is {memberEvents: MemberEvents+}
 
 context MembersAttendingEventsForAnOrganizationProjection is  {
   projection MembersAttendingEventsForAnOrganizationView is {
-    fields {
+    record fields {
         event: EventId,     //ticket-event & org-event correlation tables, event table
         eventName: String,  //event table
         eventDate: Date,     //event table

--- a/src/main/riddl/OrganizationsForMembersAttendingEventsProjection/organizationsForMembersAttendingEventsProjection.riddl
+++ b/src/main/riddl/OrganizationsForMembersAttendingEventsProjection/organizationsForMembersAttendingEventsProjection.riddl
@@ -6,7 +6,7 @@ result OrgsByMembersForEvents is {orgEventMembers: OrgMembersEvents+}
 
 context OrganizationsForMembersAttendingEventsProjections is  {
   projection OrganizationsForMembersAttendingEventsView is {
-     fields {
+     record fields {
         event: EventId,     //event table, ticket-event correlation table
         eventName: String,  //event table
         ticketSku: SKU, // ticket-event & ticket-member correlation tables

--- a/src/main/riddl/OrganizationsForMembersAttendingEventsProjection/organizationsForMembersAttendingEventsProjection.riddl
+++ b/src/main/riddl/OrganizationsForMembersAttendingEventsProjection/organizationsForMembersAttendingEventsProjection.riddl
@@ -6,7 +6,7 @@ result OrgsByMembersForEvents is {orgEventMembers: OrgMembersEvents+}
 
 context OrganizationsForMembersAttendingEventsProjections is  {
   projection OrganizationsForMembersAttendingEventsView is {
-     record fields {
+     record OrganizationsForMembersAttendingEventsFields {
         event: EventId,     //event table, ticket-event correlation table
         eventName: String,  //event table
         ticketSku: SKU, // ticket-event & ticket-member correlation tables

--- a/src/main/riddl/Tenant/tenantProjections.riddl
+++ b/src/main/riddl/Tenant/tenantProjections.riddl
@@ -6,7 +6,7 @@ result TenantByName is {
 result NoTenantWithName {}
 
 projection TenantViews is {
-    record fields {
+    record TenantFields {
         tenant: TenantId,
         tenantName: String,
         tenantInfo: TenantContext.Info

--- a/src/main/riddl/Tenant/tenantProjections.riddl
+++ b/src/main/riddl/Tenant/tenantProjections.riddl
@@ -6,7 +6,7 @@ result TenantByName is {
 result NoTenantWithName {}
 
 projection TenantViews is {
-    fields {
+    record fields {
         tenant: TenantId,
         tenantName: String,
         tenantInfo: TenantContext.Info

--- a/src/main/riddl/Venues/venueProjections.riddl
+++ b/src/main/riddl/Venues/venueProjections.riddl
@@ -1,5 +1,5 @@
 projection VenuesView is {
-    record fields {
+    record VenuesFields {
         venueId: VenueId,
         info: VenueContext.Info,
         minCapacity: Integer,

--- a/src/main/riddl/Venues/venueProjections.riddl
+++ b/src/main/riddl/Venues/venueProjections.riddl
@@ -1,5 +1,5 @@
 projection VenuesView is {
-    fields {
+    record fields {
         venueId: VenueId,
         info: VenueContext.Info,
         minCapacity: Integer,


### PR DESCRIPTION
### Issue

Currently, the Kalix-Study branch does not validate and therefore also fail in generating the static files. It turns out that the "fields" keyword has been changed such that projections require "records".

### Changes

- refactor 'fields' keywords to 'record foo'. eg. AllTenantIdsView will have the record AllTenantIdsFields

### Testing
- validated in local machine
- checked hugo server after translating